### PR TITLE
Use the Dependencies field instead of Requires

### DIFF
--- a/src/resolver/NPMv2Resolver.go
+++ b/src/resolver/NPMv2Resolver.go
@@ -22,11 +22,11 @@ func ResolveNPMV2(lockFile schemas.NPMLockFileV2) (types.LockFileInformation, er
 		}
 		dependency_name = strings.Replace(dependency_name, "node_modules/", "", 1)
 		resolvedFilePackage := types.Versions{
-			Requires:     dependency.Requires,
+			Requires:     dependency.Dependencies,
 			Dependencies: make(map[string]string),
 			Optional:     dependency.Optional,
-			Bundled:      false,
-			Dev:          false,
+			Bundled:      dependency.InBundle,
+			Dev:          dependency.Dev,
 			Scoped:       false,
 		}
 		if dep, dependency_already_present := LockFileInformation.Dependencies[dependency_name]; dependency_already_present {


### PR DESCRIPTION
As we switched to use the "packages" field instead of "dependencies" from the lockfile, the field listing all the dependencies constraints was empty.

We now use the "Dependencies" field to retrieve the constraints